### PR TITLE
fix for Django crispy forms missing template error "bootstrap4/uni_form.html"

### DIFF
--- a/solution/requirements.txt
+++ b/solution/requirements.txt
@@ -1,6 +1,6 @@
 Django
 pylint
 autopep8
-django-crispy-forms
+django-crispy-forms==1.14.0
 whitenoise
 psycopg2-binary

--- a/starter/requirements.txt
+++ b/starter/requirements.txt
@@ -1,4 +1,4 @@
 Django
 pylint
 autopep8
-django-crispy-forms
+django-crispy-forms==1.14.0


### PR DESCRIPTION
When crispy forms is used without a pinned version, a `TemplateDoesNotExist at /dog/register` error occurs when attempting to visit the `/dog/register` URL as shown below:

![TemplateDoesNotExist_at__dog_register](https://github.com/MicrosoftDocs/mslearn-django-deployment/assets/251648/52e48523-cf85-4b25-ad2d-f033b17c4983)

This PR pins crispy forms at `1.14.0` and fixes the issue.